### PR TITLE
Fix to support Mastodon v2.0+ instances

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Mastonet"]
 	path = Mastonet
-	url = https://github.com/drasticactions/Mastonet.git
+	url = https://github.com/glacasa/Mastonet.git

--- a/WinMasto/Tools/NotificationScrollingCollection.cs
+++ b/WinMasto/Tools/NotificationScrollingCollection.cs
@@ -103,7 +103,7 @@ namespace WinMasto.Tools
 
         private int _sinceId;
 
-        private int _maxId;
+        private long _maxId;
 
         private MastodonClient _client;
 

--- a/WinMasto/Tools/TimelineScrollingCollection.cs
+++ b/WinMasto/Tools/TimelineScrollingCollection.cs
@@ -15,7 +15,7 @@ namespace WinMasto.Tools
 {
     public class TimelineScrollingCollection : ObservableCollection<Status>, ISupportIncrementalLoading
     {
-        public TimelineScrollingCollection(MastodonClient client, string path, int accountId = 0)
+        public TimelineScrollingCollection(MastodonClient client, string path, long accountId = 0)
         {
             HasMoreItems = true;
             IsLoading = false;
@@ -122,9 +122,9 @@ namespace WinMasto.Tools
 
         private int _sinceId;
 
-        private int _maxId;
+        private long _maxId;
 
-        private int _accountId;
+        private long _accountId;
 
         private MastodonClient _client;
 

--- a/WinMasto/ViewModels/NewStatusPageViewModel.cs
+++ b/WinMasto/ViewModels/NewStatusPageViewModel.cs
@@ -122,12 +122,12 @@ namespace WinMasto.ViewModels
         {
             IsLoading = true;
             if (string.IsNullOrEmpty(Status) || Status.Length > 500) return;
-            IEnumerable<int> mediaIds = null;
+            IEnumerable<long> mediaIds = null;
             if (PhotoList.Any())
             {
                 mediaIds = PhotoList.Select(node => node.Attachment.Id);
             }
-            int? replyId = null;
+            long? replyId = null;
             if (ReplyStatus != null) replyId = ReplyStatus.Id;
             try
             {


### PR DESCRIPTION
Mastodon 2.0 changed API IDs to be int64s. This PR updates the Mastonet submodule and changes int->long in places where the IDs are used, so Mastodon 2.0 instances become compatible.